### PR TITLE
Rename Nimrod to Nim

### DIFF
--- a/web/index.js
+++ b/web/index.js
@@ -143,7 +143,7 @@
             'space-4': 145,
             'tab-1': 149
         },
-        'nimrod': {
+        'nim': {
             'space-2': 220,
             'space-3': 2,
             'space-4': 73


### PR DESCRIPTION
The language was renamed from Nimrod to Nim a few years ago. This also fixes the link to GitHub repository search when clicking the language name.